### PR TITLE
Fixes JavaDoc Export Command with Windows Powershell

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ export function activate(context: ExtensionContext) {
 		let runMode = vscode.workspace.getConfiguration().get('javadoc-tools.generateJavadoc.runMode');
 		if (fldrs) {
 			let cmd =
-				'"' +
+				'& "' +
 				javaHome +
 				'\\bin\\javadoc" ' +
 				runMode +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ export function activate(context: ExtensionContext) {
 		let runMode = vscode.workspace.getConfiguration().get('javadoc-tools.generateJavadoc.runMode');
 		if (fldrs) {
 			let cmd =
-				'& "' +
+				'&"' +
 				javaHome +
 				'\\bin\\javadoc" ' +
 				runMode +


### PR DESCRIPTION
Added '&' in code to allow the command to run on Windows Powershell.

